### PR TITLE
allow initialization of advertised info at the time of connection

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -60,7 +60,7 @@ var defaults = {
  * @constructor
  * @extends EventEmitter
  */
-var Discovery = function Discovery(options) {
+var Discovery = function Discovery(options, info) {
   if (!(this instanceof Discovery))
     return new Discovery(options);
 
@@ -85,6 +85,7 @@ var Discovery = function Discovery(options) {
     isMaster: false,
     isMasterEligible: true,
     weight: settings.weight,
+    info: info, // initialize the info object at the time to connection
     address: '127.0.0.1' // TODO: get the real local address?
   };
 


### PR DESCRIPTION
at the moment, start() is called inside the constructor, so "added" event never gets advertised info. This change allows for nodes to send info upfront.
